### PR TITLE
feat(datasets): update simulated data setup

### DIFF
--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -8,9 +8,8 @@ class Dataset(BaseDataset):
 
     parameters = {
         "n_samples, n_features, n_signals": [
-            (5_000, 300, 50),
-            (200, 300, 10),
-            (300, 10_000, 20),
+            (10_000, 200, 20),
+            (200, 10_000, 20),
         ],
         "rho": [0, 0.5],
     }

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -7,14 +7,20 @@ class Dataset(BaseDataset):
     name = "Simulated"
 
     parameters = {
-        "n_samples, n_features": [(5_000, 200), (200, 5_000)],
-        # "rho": [0, 0.5],
-        "rho": [0.5],
+        "n_samples, n_features, n_signals": [
+            (5_000, 300, 50),
+            (200, 300, 10),
+            (300, 10_000, 20),
+        ],
+        "rho": [0, 0.5],
     }
 
-    def __init__(self, n_samples=10, n_features=50, rho=0, random_state=27):
+    def __init__(
+        self, n_samples=10, n_features=50, n_signals=5, rho=0, random_state=27
+    ):
         self.n_samples = n_samples
         self.n_features = n_features
+        self.n_signals = n_signals
         self.random_state = random_state
         self.rho = rho
 
@@ -23,6 +29,7 @@ class Dataset(BaseDataset):
             self.n_samples,
             self.n_features,
             rho=self.rho,
+            density=self.n_signals / self.n_features,
             random_state=self.random_state,
         )
 


### PR DESCRIPTION
This PR is tangent to https://github.com/benchopt/benchmark_lasso/pull/90 and based on discussions with @mathurinm. 

Changes:

- add rho = 0 to the matrix (which should've been the case all along)
- add a n ≈ p case (or p slightly larger than n rather)
- update the dimensions somewhat (I'm not sure these choices are exactly the right ones since they're quite time-consuming)
- add an `n_signals` parameter and make sure that the signal is sparse for the p > n cases